### PR TITLE
Amend setup.py to include support for Django 1.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,6 @@ setup(
     ],
     install_requires=[
         'ProxyTypes>=0.9',
-        'Django >=1.5, <1.6a0',
+        'Django >=1.5, <1.7',
     ],
 )


### PR DESCRIPTION
django-speedbar works great - but `setup.py` limits it to Django 1.5 - in my testing it works fine with Django 1.6, so I've loosened the restriction.
