### PR TITLE
Allow a method to be monkey patched more than once

### DIFF
--- a/speedbar/modules/monkey_patching.py
+++ b/speedbar/modules/monkey_patching.py
@@ -34,6 +34,13 @@ class UnboundMethodProxy(CallableProxy):
     def __get__(self, instance, owner):
         return BoundMethodProxy(self.__subject__.__get__(instance, owner), instance or owner, self._eop_wrapper_)
 
+    def __getattribute__(self, attr, oga=object.__getattribute__):
+        """We need to return our own version of __get__ or we may end up never being called if
+        the member we are wrapping is wrapped again by someone else"""
+        if attr == '__get__':
+            return oga(self, attr)
+        return super(UnboundMethodProxy, self).__getattribute__(attr)
+
 
 def monkeypatch_method(cls, method_name=None):
     def decorator(func):


### PR DESCRIPTION
There will still be issues if patching and unpatching are done out of order. This is not fixable in the general case.
